### PR TITLE
No symmetry

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -19,8 +19,8 @@ src  = sd.load.load_freesurfer_label(os.path.join(base_dir, 'bert/label/lh.aparc
 dist = sd.surfdist.dist_calc(surf, cort, src)
 
 # visualize
-plot_med = sd.viz.viz(surf[0], surf[1], dist, bg_map=sulc, bg_on_stat=True, cmap=cmap)
-plot_lat = sd.viz.viz(surf[0], surf[1], dist, azim=180, bg_map=sulc, bg_on_stat=True, cmap=cmap)
+plot_med = sd.viz.viz(surf[0], surf[1], dist, bg_map=sulc, bg_on_stat=True, cmap=cmap, threshold=1e-50)
+plot_lat = sd.viz.viz(surf[0], surf[1], dist, azim=180, bg_map=sulc, bg_on_stat=True, cmap=cmap, threshold=1e-50)
 
 # Calculate distances on native surface and display on fsaverage
 fsa4 = nib.freesurfer.read_geometry(os.path.join(base_dir,'fsaverage4/surf/lh.sphere.reg'))[0]
@@ -29,7 +29,7 @@ native = nib.freesurfer.read_geometry(os.path.join(base_dir, 'bert/surf/lh.spher
 idx_fsa4_to_native = sd.utils.find_node_match(fsa4, native)[0]
 
 surf_fsa4 = nib.freesurfer.read_geometry(os.path.join(base_dir, 'fsaverage4/surf/lh.pial'))
-plot_fsa4_med = sd.viz.viz(surf_fsa4[0], surf_fsa4[1], dist[idx_fsa4_to_native], bg_map=fsa4_sulc, bg_on_stat=True, cmap=cmap)
-plot_fsa4_lat = sd.viz.viz(surf_fsa4[0], surf_fsa4[1], dist[idx_fsa4_to_native], azim=180, bg_map=fsa4_sulc, bg_on_stat=True, cmap=cmap)
+plot_fsa4_med = sd.viz.viz(surf_fsa4[0], surf_fsa4[1], dist[idx_fsa4_to_native], bg_map=fsa4_sulc, bg_on_stat=True, cmap=cmap, threshold=1e-50)
+plot_fsa4_lat = sd.viz.viz(surf_fsa4[0], surf_fsa4[1], dist[idx_fsa4_to_native], azim=180, bg_map=fsa4_sulc, bg_on_stat=True, cmap=cmap, threshold=1e-50)
 
 plt.show()

--- a/surfdist/viz.py
+++ b/surfdist/viz.py
@@ -20,8 +20,7 @@ def viz(coords, faces, stat_map=None,
                  give a lateral view for the right and a medial view for the
                  left hemisphere, elev=0, azim=180 will give a medial view for
                  the right and lateral view for the left hemisphere.
-    cmap : Matplotlib colormap, the color range will me forced to be symmetric.
-           Colormaps can be specified as string or colormap object.
+    cmap : Matplotlib colormap, can be specified as string or colormap object.
     threshold : float, threshold to be applied to the map, will be applied in
                 positive and negative direction, i.e. values < -abs(threshold)
                 and > abs(threshold) will be shown.
@@ -102,10 +101,8 @@ def viz(coords, faces, stat_map=None,
             stat_map_data = stat_map
             stat_map_faces = np.mean(stat_map_data[faces], axis=1)
 
-            # Ensure symmetric colour range, based on Nilearn helper function:
-            # https://github.com/nilearn/nilearn/blob/master/nilearn/plotting/img_plotting.py#L52
-            vmax = max(-np.nanmin(stat_map_faces), np.nanmax(stat_map_faces))
-            vmin = -vmax
+            vmax = np.nanmax(stat_map_faces)
+            vmin = np.nanmin(stat_map_faces)
 
             if threshold is not None:
                 kept_indices = np.where(abs(stat_map_faces) >= threshold)[0]


### PR DESCRIPTION
I started wondering whether forcing symmetry of the colormap makes so much sense in this application, as the distance values are always positive. This would is an alternative PR, where no symmetry is enforced. The problem becomes, that masked out regions are set to the same colour as regions with very small distance. This can be prevented by setting a very low threshold to prevent colouring of faces with value zero. Yet, this also leads to the seed regions being left blank. 
I am not sure which of the different versions is preferable. None seems ideal, on the long run a masking option should be integrated.

Results of demo.py without symmetric color map:
![unsymmetric_fsavg4lat](https://cloud.githubusercontent.com/assets/6514016/11458206/f9c1db0c-96bb-11e5-8d44-e8994afee743.png)
![unsymmetric_fsavgmed](https://cloud.githubusercontent.com/assets/6514016/11458207/fd897bc8-96bb-11e5-9f2a-757f75a30125.png)

... with threshold
![unsymmetric_thr_fsavg_lat](https://cloud.githubusercontent.com/assets/6514016/11458209/008b3b5e-96bc-11e5-8bf7-c9bb7c653db4.png)
![unsymmetric_thr_fsavg_med](https://cloud.githubusercontent.com/assets/6514016/11458210/03430fac-96bc-11e5-99a7-3f348fac9e3b.png)



